### PR TITLE
Add AssetCollector

### DIFF
--- a/config/contentBlocks/counter/src/EditorPreview.html
+++ b/config/contentBlocks/counter/src/EditorPreview.html
@@ -1,6 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
   
-<f:asset.css id="content-block-counter" path="CB:counter/dist/EditorPreview.css">
+<f:asset.css id="content-block-counter-be" path="CB:counter/dist/EditorPreview.css">
 
 <div class="counter">
   <span class="counter-value">{amount}</span>

--- a/config/contentBlocks/counter/src/EditorPreview.html
+++ b/config/contentBlocks/counter/src/EditorPreview.html
@@ -1,4 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+  
+<f:asset.css id="content-block-counter" path="CB:counter/dist/EditorPreview.css">
+
 <div class="counter">
   <span class="counter-value">{amount}</span>
   <span class="counter-icon">

--- a/config/contentBlocks/counter/src/Frontend.html
+++ b/config/contentBlocks/counter/src/Frontend.html
@@ -1,4 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+<f:asset.css id="content-block-counter" path="CB:counter/dist/Frontend.css">
+<f:asset.js id="content-block-counter" path="CB:counter/dist/Frontend.js">
+
 <div class="counter">
   <span class="counter-value">{amount}</span>
   <span class="counter-icon">

--- a/config/contentBlocks/slider/src/EditorPreview.html
+++ b/config/contentBlocks/slider/src/EditorPreview.html
@@ -1,4 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+  
+<f:asset.css id="content-block-slider-be" path="CB:slider/dist/EditorPreview.css">
+  
   <div class="slider">
     <f:for each="{slides}" as="slide" iteration="iteration">
       <div class="slider-item">

--- a/config/contentBlocks/slider/src/Frontend.html
+++ b/config/contentBlocks/slider/src/Frontend.html
@@ -1,4 +1,8 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+  
+<f:asset.css id="content-block-counter" path="CB:counter/dist/Frontend.css">
+<f:asset.js id="content-block-counter" path="CB:counter/dist/Frontend.js">
+  
   <div class="slider" data-autoplay="{autoplay}">
     <f:for each="{slides}" as="slide" iteration="iteration">
       <div class="slider-item">

--- a/config/contentBlocks/slider/src/Frontend.html
+++ b/config/contentBlocks/slider/src/Frontend.html
@@ -1,7 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
   
-<f:asset.css id="content-block-counter" path="CB:counter/dist/Frontend.css">
-<f:asset.js id="content-block-counter" path="CB:counter/dist/Frontend.js">
+<f:asset.css id="content-block-slider" path="CB:slider/dist/Frontend.css">
+<f:asset.js id="content-block-slider" path="CB:slider/dist/Frontend.js">
   
   <div class="slider" data-autoplay="{autoplay}">
     <f:for each="{slides}" as="slide" iteration="iteration">


### PR DESCRIPTION
# Asset Handling in Content Blocks


FAQ: https://github.com/TYPO3-Initiatives/structured-content/blob/master/Documentation/ContentBlocks/FAQ.md#how-can-existing-content-blocks-be-overridden

In regards to the faq question, we had some thoughts how to solve this issue. 
Our conclusion is as simple as it can be: Use AssetCollector.




Use AssetCollector:
- Include <f:asset.css id=”contentBlockName” path=“dist/Frontend.css”>
- Include <f:asset.js id=”contentBlockName” path=“dist/Frontend.js”>
- Solves: 
    -  dependencies for and reusing Frontend.css/Frontend.js (FAQ How can I use the same CSS/ JavaScript or library assets across multiple content blocks?)
    - different workflow (no css/js per contentBlock)


What will the public URL and the local path of the dist/-folder be?

Use case: 
- Include asset with <f:asset…>
- Dynamically load asset from JavaScript
- Use the asset from another contentBlock (/config/contentBlocks/…?)

Proposal:
- Have a well-known URL + local path (e.g. via symlinking as done with extensions)
- Add prefix, e.g. “CB:”

