### PR TITLE
[BUGFIX] have content blocks require typo3-contentblocks/contentblocks-reg-api

### DIFF
--- a/Documentation/ContentBlocks/ContentBlockRegistration.md
+++ b/Documentation/ContentBlocks/ContentBlockRegistration.md
@@ -67,7 +67,8 @@ The content block ID (CType) derives from the package name. Therefore one compos
 
 **You must**
 * provide that file
-* set the type property to: typo3-cms-contentblock
+* set the type property to: `typo3-cms-contentblock`
+* require `"typo3-contentblocks/contentblocks-reg-api": "*"`
 
 **You may**
 * use the full composer.json config and define autoloading for ViewHelpers etc.

--- a/config/contentBlocks/counter/composer.json
+++ b/config/contentBlocks/counter/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sci/counter",
+  "name": "typo3-contentblocks/counter",
   "description": "Content block providing animated counter.",
   "type": "typo3-cms-contentblock-fluid",
   "license": "GPL-2.0-or-later",

--- a/config/contentBlocks/counter/composer.json
+++ b/config/contentBlocks/counter/composer.json
@@ -1,14 +1,14 @@
 {
-    "name": "sci/counter",
-    "description": "Content block providing animated counter.",
-    "type": "typo3-cms-contentblock-fluid",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "Structured Content Initiative"
-        }
-    ],
-    "require": {
-        "typo3fluid/fluid": "^2.6"
+  "name": "sci/counter",
+  "description": "Content block providing animated counter.",
+  "type": "typo3-cms-contentblock-fluid",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Structured Content Initiative"
     }
+  ],
+  "require": {
+    "typo3-contentblocks/contentblocks-reg-api": "*"
+  }
 }

--- a/config/contentBlocks/slider/composer.json
+++ b/config/contentBlocks/slider/composer.json
@@ -1,14 +1,14 @@
 {
-    "name": "sci/slider",
-    "description": "Content block with multiple slides switched by autoplay.",
-    "type": "typo3-cms-contentblock-fluid",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "Structured Content Initiative"
-        }
-    ],
-    "require": {
-        "typo3fluid/fluid": "^2.6"
+  "name": "sci/slider",
+  "description": "Content block with multiple slides switched by autoplay.",
+  "type": "typo3-cms-contentblock-fluid",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Structured Content Initiative"
     }
+  ],
+  "require": {
+    "typo3-contentblocks/contentblocks-reg-api": "*"
+  }
 }

--- a/config/contentBlocks/slider/composer.json
+++ b/config/contentBlocks/slider/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sci/slider",
+  "name": "typo3-contentblocks/slider",
   "description": "Content block with multiple slides switched by autoplay.",
   "type": "typo3-cms-contentblock-fluid",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
For reasoning see TYPO3-Initiatives/content-block-registration-api#11

Fixes TYPO3-Initiatives/content-block-registration-api#11﻿
Fixes #21
